### PR TITLE
ci: Improve workflow's securiy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Check out code
+      - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,16 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: { }
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build-n-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
 
-permissions: { }
-
 jobs:
   pinact:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-      workflows: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,23 @@
+name: Pinact
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: { }
+
+jobs:
+  pinact:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      workflows: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Pin actions
+        uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.1.2

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -22,6 +22,7 @@ jobs:
 
       # TODO Consider using `taiki-e/install-action` instead of `baptiste0928/cargo-install`.
       #  See: https://github.com/taiki-e/install-action
+      # TODO Set `sign-commit` field or `--sign-commit` flag, OR don't use cargo-release.
       - name: Install cargo-release from crates.io
         uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -15,10 +15,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       # TODO Consider using `taiki-e/install-action` instead of `baptiste0928/cargo-install`.
       #  See: https://github.com/taiki-e/install-action

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -3,9 +3,7 @@ name: Prepare Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: { }
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,7 +11,9 @@ env:
 jobs:
   crate-release-pull-request:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -22,7 +22,6 @@ jobs:
 
       # TODO Consider using `taiki-e/install-action` instead of `baptiste0928/cargo-install`.
       #  See: https://github.com/taiki-e/install-action
-      # TODO Exec with `--sign` flag, OR don't use cargo-release.
       - name: Install cargo-release from crates.io
         uses: baptiste0928/cargo-install@v3
         with:
@@ -68,6 +67,7 @@ jobs:
             --no-tag \
             --no-confirm \
             --execute \
+            --sign \
             --verbose
           new_version=$(cargo pkgid | cut -d@ -f2)
           echo "Proposed new version=$new_version"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -22,7 +22,7 @@ jobs:
 
       # TODO Consider using `taiki-e/install-action` instead of `baptiste0928/cargo-install`.
       #  See: https://github.com/taiki-e/install-action
-      # TODO Set `sign-commit` field or `--sign-commit` flag, OR don't use cargo-release.
+      # TODO Exec with `--sign` flag, OR don't use cargo-release.
       - name: Install cargo-release from crates.io
         uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,12 +6,13 @@ name: Publish Release
 #    tags:
 #      - 'v*.*.*'
 
+permissions: { }
+
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,7 +14,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Create tag
         # TODO fetch version and create tag

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Create tag
-        # TODO fetch version and create tag
+      # TODO fetch version and create tag
+      #- name: Create tag
 
       # TODO create release ??
 


### PR DESCRIPTION
## Description of changes

This pull request includes several updates to the GitHub Actions workflows to enhance security and functionality. The most important changes involve adding permissions configurations, introducing a new workflow for pinning actions, and updating existing workflows to improve clarity and security.

### Permissions Configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9-R23): Added empty `permissions` object at the workflow level and specified read permissions for `contents` in the `build-n-test` job. Also, disabled credential persistence for the checkout step.
* [`.github/workflows/release-prepare.yml`](diffhunk://#diff-c653f3e33b01c829488a4008bada88d6987346456be9abb31ce6064ea518410aL6-R23): Replaced specific permissions with an empty `permissions` object at the workflow level and re-added specific permissions for the `crate-release-pull-request` job. Disabled credential persistence for the checkout step.
* [`.github/workflows/release-publish.yml`](diffhunk://#diff-c6d47dacf31662f6791d0cf218b1d34ee0ab48348c037819431cdd40e3fc23e4R9-R23): Added an empty `permissions` object at the workflow level and changed `contents` permissions from write to read in the `release` job. Disabled credential persistence for the checkout step.

### New Workflow:

* [`.github/workflows/pinact.yml`](diffhunk://#diff-c83618ba4f08a10c02f67af2e51c401995a4cc2424f79e0e2032383d26b29997R1-R23): Introduced a new workflow named "Pinact" to pin actions used in the repository. This includes setting up permissions, specifying the branch to trigger on, and defining steps for checking out the code and pinning actions.

### Additional Improvements:

* [`.github/workflows/release-prepare.yml`](diffhunk://#diff-c653f3e33b01c829488a4008bada88d6987346456be9abb31ce6064ea518410aR72): Added the `--sign` flag to the `cargo release` command to enable signing of the release.
